### PR TITLE
Do not abort vlog parsing if body size is wrong

### DIFF
--- a/parseVlog.py
+++ b/parseVlog.py
@@ -180,8 +180,10 @@ def parseVlog(vlog):
                 compTimesPerLevel[levelName] = [usec]
 
             bodySize = methodEndAddr - methodStartAddr
-            assert bodySize > 0, "Method size must be positive"
-            compBodySizes.append(bodySize)
+            if bodySize > 0:
+                compBodySizes.append(bodySize)
+            else:
+                print("Warning: detected negative body size in line", line)
 
             if printCompTimeCDF:
                 mName = methodName + "_" + str(usec)


### PR DESCRIPTION
Existing code had an assert that the computed compiled body size must be positive. While this is valid, we would like to ignore this error (only give an warning) and continue to parse the vlog and produce stats.