### PR TITLE
Added loop-curl.sh script for RestCRUD benchmark

### DIFF
--- a/loop_curl.sh
+++ b/loop_curl.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:9090/fruits)" != "200" ]]; do sleep .00001; done'
+date +"%H:%M:%S.%N"
+


### PR DESCRIPTION
This script sends http requests continuously until one of teh requests succeeds. It is to measure the time to first request for the RestCRUD benchmark.